### PR TITLE
New functionality: verifying firmware and -v mode

### DIFF
--- a/ch341a.h
+++ b/ch341a.h
@@ -20,10 +20,10 @@
 #ifndef __CH341_H__
 #define __CH341_H__
 
-#ifdef __cplusplus                              
+#ifdef __cplusplus
 extern "C" {
 #endif
-#define     DEFAULT_TIMEOUT        1000     // 300mS for USB timeouts
+#define     DEFAULT_TIMEOUT        1000     // 1000mS for USB timeouts
 #define     BULK_WRITE_ENDPOINT    0x02
 #define     BULK_READ_ENDPOINT     0x82
 
@@ -77,7 +77,7 @@ int32_t ch341SpiWrite(uint8_t *buf, uint32_t add, uint32_t len);
 int32_t ch341Release(void);
 uint8_t swapByte(uint8_t c);
 
-#ifdef __cplusplus                              
+#ifdef __cplusplus
 }
 #endif
 

--- a/main.c
+++ b/main.c
@@ -54,8 +54,8 @@ int main(int argc, char* argv[])
         {"write",   required_argument,  0, 'w'},
         {"length",   required_argument,  0, 'l'},
         {"read",    required_argument,  0, 'r'},
-	{"turbo",   no_argument,  0, 't'},
-	{"double",  no_argument,  0, 'd'},
+        {"turbo",   no_argument,  0, 't'},
+        {"double",  no_argument,  0, 'd'},
         {0, 0, 0, 0}};
 
         int32_t optidx = 0;
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
     ret = ch341SpiCapacity();
     if (ret < 0) goto out;
     cap = 1 << ret;
-    printf("Chip capacity is %d\n", cap);
+    printf("Chip capacity is %d bytes\n", cap);
 
     if (length != 0){
 	cap = length;


### PR DESCRIPTION
Hello!

Thank you for this tool. Me and my colleagues&friends use it almost everyday for flashing winbound and microchip spi rom. 

I've made a few changes. 
* Add verifying flashed firmware after writing
* Add -v option to display read/write status. I took it from [this](https://github.com/vSlipenchuk/ch341prog) fork, all regards to @vSlipenchuk
* Add simple displaying status for erase process

We checked the code on some w25q128 and w25q256 chips, works well. It would be great to make review and maybe merge it in the future. Thanks.