### PR TITLE
Add udev rule file

### DIFF
--- a/99-ch341a-prog.rules
+++ b/99-ch341a-prog.rules
@@ -1,0 +1,3 @@
+# udev rule that sets permissions for CH341A programmer in Linux.
+# Put this file in /etc/udev/rules.d and reload udev rules or reboot to install
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5512", MODE="0666"

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,7 @@ ch341prog: main.c ch341a.c ch341a.h
 	gcc $(CFLAGS) ch341a.c main.c -o ch341prog  -lusb-1.0
 clean:
 	rm *.o ch341prog -f
-.PHONY: clean
+install-udev-rule:
+	cp 99-ch341a-prog.rules /etc/udev/rules.d/
+	udevadm control --reload-rules
+.PHONY: clean install-udev-rule

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Speed Test
 -----------
  * read a 8M flash(W25Q64) costs 101.840 seconds
  * write to an 8M flash(W25Q64) costs 158.811 seconds
+
+Linux Permissions
+------------------
+To ensure the CH341 programmer will be set up with proper permissions on a Linux computer, run the following command to install a udev rule file into /etc/udev/rules.d:
+
+`sudo make install-udev-rule`


### PR DESCRIPTION
This commit adds a udev rule file that can be placed in /etc/udev/rules.d to set permissions so that you won't need to run the software as root in Linux.